### PR TITLE
feat: add fromNumber

### DIFF
--- a/src/decimal.test.ts
+++ b/src/decimal.test.ts
@@ -60,4 +60,29 @@ describe("the BIP class", () => {
       "1,000,000.111111"
     );
   });
+
+  it("ensures values can be created from number", () => {
+    expect(BIP.fromNumber(100).unscale(18n)).toBe(100n * 10n ** 18n);
+    expect(BIP.fromNumber(1.0).unscale(4n)).toBe(1n * 10n ** 4n);
+  });
+
+  it("ensures that maths can be used fromNumber", () => {
+    const summands = BIP.fromNumber(2);
+    const sum = summands.add(BIP.fromNumber(1.14159)).unscale(5n);
+    expect(sum).toEqual(3_14159n);
+
+    const minuend = BIP.fromNumber(10.0);
+    const difference = minuend.sub(BIP.fromNumber(6.8584)).unscale(4n);
+    expect(difference).toEqual(3_1416n);
+
+    const multiplicand = BIP.fromNumber(300.0);
+    const product = multiplicand.mul(BIP.fromNumber(5)).unscale(2n);
+    expect(product).toEqual(150000n);
+
+    // https://mathworld.wolfram.com/PiApproximations.html
+    const dividend = BIP.fromNumber(8405139762.0);
+    const divisor = BIP.fromNumber(2675439081);
+    const quotient = dividend.div(divisor).unscale(18n);
+    expect(quotient).toBe(3_141592653591053677n);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,15 @@ export default class BIP {
   static from(value: bigint, exponent: bigint = 0n): BIP {
     return new BIP(value, exponent);
   }
+  static fromNumber(value: number): BIP {
+    if (Number.isInteger(value)) return new BIP(BigInt(value));
+    // split number into whole and fractional
+    const whole = Math.trunc(value);
+    const fractional = value.toString().split(".")[1];
+    const exponent = BigInt(fractional.length);
+    const bigInt = BigInt(`${whole}${fractional}`);
+    return new BIP(bigInt, exponent);
+  }
 
   unscale(precision: bigint): bigint {
     const diff = INTERNAL_SCALE - precision;


### PR DESCRIPTION
Closes #12 

I realised while integrated fromFloat, I needed to add a fail safe for a whole number.

Instead, I decided it would be better usability to be able to use fromNumber() with whole and floating point numbers.