### PR TITLE
fix: parse scientific numbers on string

### DIFF
--- a/src/decimal.test.ts
+++ b/src/decimal.test.ts
@@ -85,4 +85,12 @@ describe("the BIP class", () => {
     const quotient = dividend.div(divisor).unscale(18n);
     expect(quotient).toBe(3_141592653591053677n);
   });
+
+  it("does not output scientific notification on toString", () => {
+    const multiplicand = BIP.from(300_00000n, 5n);
+    const product = multiplicand
+      .mul(BIP.from(500000000012121212120n))
+      .toString();
+    expect(product).toEqual("150000000003636370000000");
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { BN } from "@project-serum/anchor";
+import parseScientific from "./utils/parseScientific";
 
 type FormatLocale = "de-DE" | "en-US";
 
@@ -87,7 +88,7 @@ export default class BIP {
 
   toString(): string {
     const unscaledNumber = toBIP(this.#scaled).toNumber();
-    return `${unscaledNumber}`;
+    return parseScientific(`${unscaledNumber}`);
   }
 
   toFormat(locale: FormatType, fractionalLength: number = 8): string {

--- a/src/utils/parseScientific.ts
+++ b/src/utils/parseScientific.ts
@@ -1,0 +1,36 @@
+// This was taken directly from https://gist.github.com/jiggzson/b5f489af9ad931e3d186?permalink_comment_id=3723670#gistcomment-3723670
+
+export default function parseScientific(num: string): string {
+  // If the number is not in scientific notation return it as it is.
+  if (!/\d+\.?\d*e[+-]*\d+/i.test(num)) {
+    return num;
+  }
+
+  // Remove the sign.
+  const numberSign = Math.sign(Number(num));
+  num = Math.abs(Number(num)).toString();
+
+  // Parse into coefficient and exponent.
+  const [coefficient, exponent] = num.toLowerCase().split("e");
+  let zeros = Math.abs(Number(exponent));
+  const exponentSign = Math.sign(Number(exponent));
+  const [integer, decimals] = (
+    coefficient.indexOf(".") != -1 ? coefficient : `${coefficient}.`
+  ).split(".");
+
+  if (exponentSign === -1) {
+    zeros -= integer.length;
+    num =
+      zeros < 0
+        ? integer.slice(0, zeros) + "." + integer.slice(zeros) + decimals
+        : "0." + "0".repeat(zeros) + integer + decimals;
+  } else {
+    if (decimals) zeros -= decimals.length;
+    num =
+      zeros < 0
+        ? integer + decimals.slice(0, zeros) + "." + decimals.slice(zeros)
+        : integer + decimals + "0".repeat(zeros);
+  }
+
+  return numberSign < 0 ? "-" + num : num;
+}


### PR DESCRIPTION
Closes #14 

Scientific numbers were shown on string, which defeats the purpose.

I ripped a scientific number parser from  https://gist.github.com/jiggzson/b5f489af9ad931e3d186?permalink_comment_id=3723670#gistcomment-3723670