### PR TITLE
feat: allow fromNumber to take scientific notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ BIP.from(3_141590n, 6n)
 
 <sup>We add \_ as it's an easier visual cue to track it</sup>
 
+## fromNumber
+
+.fromNumber can take a whole number, floating point or evemn scientific notation as an input and allow you to perform big maths on it.
+
+```
+BIP.fromNumber(20000)
+BIP.fromNumber(20.12221)
+BIP.fromNumber("1.2112222222222222e+22");
+```
+
 ## Return the value
 
 To return the value after applying some maths, we have the following options.

--- a/src/decimal.test.ts
+++ b/src/decimal.test.ts
@@ -93,4 +93,22 @@ describe("the BIP class", () => {
       .toString();
     expect(product).toEqual("150000000003636370000000");
   });
+
+  it("ensures that scientific notation can be used with fromNumber with a floating point number", () => {
+    const summands = BIP.fromNumber("1.2112222222222222e+22");
+    const sum = summands.add(BIP.fromNumber(1.14159)).unscale(23n);
+    expect(sum).toEqual(1211222222222222200000114159000000000000000000n);
+  });
+
+  it("ensures that scientific notation can be used with fromNumber with a whole number", () => {
+    const summands = BIP.fromNumber("2e+2");
+    const sum = summands.add(BIP.fromNumber(1.14159)).unscale(23n);
+    expect(sum).toEqual(20114159000000000000000000n);
+  });
+
+  // it("throws error if fromNumber is not number or scientific notation", () => {
+  //   expect(BIP.fromNumber("value")).toThrowError(
+  //     "You have entered a value that isn't a number or scientific notation"
+  //   );
+  // });
 });

--- a/src/utils/parseScientific.ts
+++ b/src/utils/parseScientific.ts
@@ -1,8 +1,15 @@
-// This was taken directly from https://gist.github.com/jiggzson/b5f489af9ad931e3d186?permalink_comment_id=3723670#gistcomment-3723670
+// This was taken from https://gist.github.com/jiggzson/b5f489af9ad931e3d186?permalink_comment_id=3723670#gistcomment-3723670
+
+export function checkScientific(num: string) {
+  if (/\d+\.?\d*e[+-]*\d+/i.test(num)) {
+    return true;
+  }
+  return false;
+}
 
 export default function parseScientific(num: string): string {
   // If the number is not in scientific notation return it as it is.
-  if (!/\d+\.?\d*e[+-]*\d+/i.test(num)) {
+  if (!checkScientific(num)) {
     return num;
   }
 


### PR DESCRIPTION
Closes #20 

I realised that some number inputs might accidentally be scientific notation, instead of getting the user to parse them, I added our inbuilt parser.